### PR TITLE
Add e2e setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,21 @@
 sudo: required
 
+env:
+  global:
+    - KUBECTL_VERSION=v1.13.0
+    - KIND_VERSION=0.1.0
+    - KIND_CLUSTER=es-e2e
+
 services:
   - docker
 
-script: make travis
+before_script:
+  # Install kubectl.
+  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+  # Download and install KinD
+  - curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64 && chmod +x kind && sudo mv kind /usr/local/bin/
+
+script: make KIND_CLUSTER=${KIND_CLUSTER}
 
 deploy:
 - provider: script

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,13 @@
+source 'https://rubygems.org'
+
+gem 'activesupport', '~>5.2.2'
+gem 'fluentd', '<=1.3.3'
+gem 'fluent-plugin-concat', '~>2.3.0'
+gem 'fluent-plugin-detect-exceptions', '~>0.0.11'
+gem 'fluent-plugin-elasticsearch', '~>3.0.1'
+gem 'fluent-plugin-kubernetes_metadata_filter', '~>2.1.6'
+gem 'fluent-plugin-multi-format-parser', '~>1.0.0'
+gem 'fluent-plugin-prometheus', '~>1.3.0'
+gem 'fluent-plugin-systemd', '~>1.0.1'
+gem 'fluent-plugin-rewrite-tag-filter', '~>2.1.1'
+gem 'oj', '~>3.7.6'

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,64 @@
-.PHONY: all docker
+THIS_FILE := $(lastword $(MAKEFILE_LIST))
+KIND_CLUSTER := "es-e2e"
 
-all : docker
-travis : docker
+define kind_kubeconfig
+	$(shell kind get kubeconfig-path --name $(KIND_CLUSTER))
+endef
 
 # Docker build
 git_rev := $(shell git rev-parse --short HEAD)
 git_tag := $(shell git tag --points-at=$(git_rev))
 image_prefix := skycirrus/fluentd-docker
+image_latest := $(image_prefix):latest
+image_file := fluentd-docker.tar.gz
+kind_node_prefix := kind-$(KIND_CLUSTER)-
 
+all: docker kind kind-docker-load-image kind-deploy-resources e2e kind-cleanup
+
+.PHONY: docker
 docker :
 	@echo "== build docker images"
-	docker build -t $(image_prefix):latest .
+	docker build -t $(image_latest) .
+
+.PHONY: kind-cleanup
+kind-cleanup:
+	@echo "== delete local KinD $(KIND_CLUSTER) cluster"
+	kind delete cluster --name=$(KIND_CLUSTER)
+
+.PHONY: kind
+kind: kind-cleanup
+	@echo "== create local KinD $(KIND_CLUSTER) cluster"
+	# Create a new KinD cluster using a custom configuration
+	kind create cluster --name=$(KIND_CLUSTER) --config e2e/kind.conf
+
+.PHONY: kind-docker-load-image
+kind-docker-load-image:
+	@echo "== load image into KinD $(KIND_CLUSTER) cluster"
+	@# Export generated Docker image to an archive.
+	docker save $(image_latest) -o $(image_file)
+	@# Copy saved archive into kind's Docker containers and
+	@# Import image into their Docker daemon to make it accessible to Kubernetes.
+	@for node in "control-plane" "worker" ; do \
+		echo "- loading image '$(image_latest)' to $$node" ; \
+		docker cp $(image_file) $(kind_node_prefix)$$node:/$(image_file) ; \
+		docker exec $(kind_node_prefix)$$node docker load -i /$(image_file) ; \
+	done
+	@# Cleanup archive
+	rm $(image_file)
+
+.PHONY: kind-deploy-resources
+kind-deploy-resources:
+	@echo "== deploy k8s resources into KinD $(KIND_CLUSTER) cluster"
+	@echo "-- elasticsearch"
+	kubectl --kubeconfig $(call kind_kubeconfig) apply -f e2e/resources/es
+	@echo "-- fluentd"
+	kubectl --kubeconfig $(call kind_kubeconfig) apply -f e2e/resources/fluentd
+	@echo "-- logging-pod"
+	kubectl --kubeconfig $(call kind_kubeconfig) apply -f e2e/resources/logging-pod.yml
+
+.PHONY: e2e
+e2e: kind-deploy-resources
+	@echo "== run end to end tests"
 
 release : docker
 	@echo "== release docker images"
@@ -19,7 +67,7 @@ ifeq ($(strip $(git_tag)),)
 else
 	@echo "releasing $(image):$(git_tag)"
 	@docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD)
-	docker tag $(image_prefix):latest $(image_prefix):$(git_tag)
+	docker tag $(image_latest) $(image_prefix):$(git_tag)
 	docker push $(image_prefix):$(git_tag)
-	docker push $(image_prefix):latest
+	docker push $(image_latest)
 endif

--- a/e2e/kind.conf
+++ b/e2e/kind.conf
@@ -1,0 +1,6 @@
+kind: Config
+apiVersion: kind.sigs.k8s.io/v1alpha2
+nodes:
+  - role: control-plane
+  - role: worker
+    replicas: 1

--- a/e2e/resources/es/es-service.yml
+++ b/e2e/resources/es/es-service.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch-logging
+  namespace: kube-system
+  labels:
+    k8s-app: elasticsearch-logging
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "Elasticsearch"
+spec:
+  ports:
+    - port: 9200
+      protocol: TCP
+      targetPort: db
+  selector:
+    k8s-app: elasticsearch-logging

--- a/e2e/resources/es/es-statefulset.yml
+++ b/e2e/resources/es/es-statefulset.yml
@@ -1,0 +1,110 @@
+# RBAC authn and authz
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: elasticsearch-logging
+  namespace: kube-system
+  labels:
+    k8s-app: elasticsearch-logging
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: elasticsearch-logging
+  labels:
+    k8s-app: elasticsearch-logging
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "services"
+      - "namespaces"
+      - "endpoints"
+    verbs:
+      - "get"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kube-system
+  name: elasticsearch-logging
+  labels:
+    k8s-app: elasticsearch-logging
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+subjects:
+  - kind: ServiceAccount
+    name: elasticsearch-logging
+    namespace: kube-system
+    apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: elasticsearch-logging
+  apiGroup: ""
+---
+# Elasticsearch deployment itself
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch-logging
+  namespace: kube-system
+  labels:
+    k8s-app: elasticsearch-logging
+    version: v6.6.1
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  serviceName: elasticsearch-logging
+  replicas: 2
+  selector:
+    matchLabels:
+      k8s-app: elasticsearch-logging
+      version: v6.6.1
+  template:
+    metadata:
+      labels:
+        k8s-app: elasticsearch-logging
+        version: v6.6.1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      serviceAccountName: elasticsearch-logging
+      containers:
+        - image: gcr.io/fluentd-elasticsearch/elasticsearch:v6.6.1
+          name: elasticsearch-logging
+          resources:
+            # need more cpu upon initialization, therefore burstable class
+            limits:
+              cpu: 1000m
+            requests:
+              cpu: 100m
+          ports:
+            - containerPort: 9200
+              name: db
+              protocol: TCP
+            - containerPort: 9300
+              name: transport
+              protocol: TCP
+          volumeMounts:
+            - name: elasticsearch-logging
+              mountPath: /data
+          env:
+            - name: "NAMESPACE"
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      volumes:
+        - name: elasticsearch-logging
+          emptyDir: {}
+      # Elasticsearch requires vm.max_map_count to be at least 262144.
+      # If your OS already sets up this number to a higher value, feel free
+      # to remove this init container.
+      initContainers:
+        - image: alpine:3.6
+          command: ["/sbin/sysctl", "-w", "vm.max_map_count=262144"]
+          name: elasticsearch-logging-init
+          securityContext:
+            privileged: true

--- a/e2e/resources/es/es-template.yml
+++ b/e2e/resources/es/es-template.yml
@@ -1,0 +1,101 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: elasticsearch-template
+  namespace: kube-system
+data:
+  template.json: |-
+    {
+      "template": "logs-kind-*",
+      "settings": {
+        "number_of_shards": 1,
+        "number_of_replicas": 0,
+        "index.mapping.ignore_malformed": true
+      },
+      "mappings": {
+        "flb_type": {
+          "dynamic": true,
+          "dynamic_templates": [
+            {
+              "custom_app_fields" : {
+                "match_mapping_type": "string",
+                "mapping": { "type": "keyword" }
+              }
+            }
+          ],
+          "properties": {
+            "message": {
+              "type": "text"
+            },
+            "@shipper-timestamp": {
+              "type": "date",
+              "format": "strict_date_optional_time||epoch_millis"
+            },
+            "@timestamp": {
+              "type": "date",
+              "format": "strict_date_optional_time||epoch_millis"
+            },
+            "docker": {
+              "properties": {
+                "container_id": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "kubernetes": {
+              "properties": {
+                "annotations": {
+                  "type": "object"
+                },
+                "container_name": {
+                  "type": "keyword"
+                },
+                "host": {
+                  "type": "keyword"
+                },
+                "labels": {
+                  "properties": {
+                    "app": {
+                      "type": "keyword"
+                    },
+                    "deployment": {
+                      "type": "keyword"
+                    },
+                    "k8s-app": {
+                      "type": "keyword"
+                    },
+                    "kubernetes_io/cluster-service": {
+                      "type": "keyword"
+                    },
+                    "pod-template-hash": {
+                      "type": "keyword"
+                    },
+                    "version": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "cluster": {
+                  "type": "keyword"
+                },
+                "namespace_name": {
+                  "type": "keyword"
+                },
+                "pod_id": {
+                  "type": "keyword"
+                },
+                "pod_name": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "log": {
+              "type": "text"
+            },
+            "stream": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }

--- a/e2e/resources/fluentd/fluentd-configmap.yml
+++ b/e2e/resources/fluentd/fluentd-configmap.yml
@@ -1,0 +1,152 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluentd-config
+  namespace: kube-system
+data:
+  containers.input.conf: |-
+    <source>
+      @type tail
+      path /var/log/containers/*.log
+      exclude_path /var/log/containers/fluentd*
+      pos_file /var/log/fluentd-containers.log.pos
+      tag kubernetes.*
+      <parse>
+        @type multi_format
+        <pattern>
+          format json
+          time_key time
+          time_format %Y-%m-%dT%H:%M:%S.%NZ
+        </pattern>
+        <pattern>
+          format none
+          time_format %Y-%m-%dT%H:%M:%S.%N%:z
+        </pattern>
+      </parse>
+    </source>
+
+    <filter kubernetes.**>
+      @type kubernetes_metadata
+    </filter>
+
+    <filter kubernetes.var.log.containers.**>
+      @type parser
+      <parse>
+        @type json
+        json_parser json
+      </parse>
+      replace_invalid_sequence true
+      emit_invalid_record_to_error false
+      key_name log
+      reserve_data true
+    </filter>
+
+    <filter kubernetes.**>
+      @type record_transformer
+      enable_ruby true
+      <record>
+        @team_index logs-kind-${record['kubernetes']['labels']['team'] || 'default'}-${time.strftime("%Y.%m.%d")}
+      </record>
+    </filter>
+
+    <match **>
+        @type elasticsearch
+        @log_level info
+        templates { "kindflb": "/etc/fluent/es-template/template.json" }
+        include_tag_key true
+        host elasticsearch-logging
+        port 9200
+        scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'http'}"
+        ssl_verify "#{ENV['FLUENT_ELASTICSEARCH_SSL_VERIFY'] || 'true'}"
+        reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'false'}"
+        target_index_key @team_index
+        logstash_format true
+        type_name flb_type
+        <buffer>
+          flush_thread_count "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_FLUSH_THREAD_COUNT'] || '8'}"
+          flush_interval "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_FLUSH_INTERVAL'] || '5s'}"
+          chunk_limit_size "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_CHUNK_LIMIT_SIZE'] || '2M'}"
+          queue_limit_length "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_QUEUE_LIMIT_LENGTH'] || '32'}"
+          retry_max_interval "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_RETRY_MAX_INTERVAL'] || '30'}"
+        retry_forever true
+        </buffer>
+      </match>
+
+      <match **>
+        @type stdout
+      </match>
+
+    <label @ERROR>
+      <filter kubernetes.**>
+        @type record_transformer
+        enable_ruby true
+        <record>
+          @team_index logs-kind-failed-${record['kubernetes']['labels']['team'] || 'default'}-${time.strftime("%Y.%m.%d")}
+        </record>
+      </filter>
+
+      <match **>
+        @type elasticsearch
+        @log_level info
+        templates { "kindflb": "/etc/fluent/es-template/template.json" }
+        flatten_hashes true
+        flatten_hashes_separator _
+        include_tag_key true
+        host elasticsearch-logging
+        port 9200
+        scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'http'}"
+        ssl_verify "#{ENV['FLUENT_ELASTICSEARCH_SSL_VERIFY'] || 'true'}"
+        reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'true'}"
+        target_index_key @team_index
+        logstash_format true
+        type_name flb_type
+        <buffer>
+          flush_thread_count "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_FLUSH_THREAD_COUNT'] || '8'}"
+          flush_interval "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_FLUSH_INTERVAL'] || '5s'}"
+          chunk_limit_size "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_CHUNK_LIMIT_SIZE'] || '2M'}"
+          queue_limit_length "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_QUEUE_LIMIT_LENGTH'] || '32'}"
+          retry_max_interval "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_RETRY_MAX_INTERVAL'] || '30'}"
+        retry_forever false
+        </buffer>
+      </match>
+    </label>
+
+  monitoring.conf: |-
+    # Prometheus Exporter Plugin
+    # input plugin that exports metrics
+    <source>
+        @id prometheus
+        @type prometheus
+    </source>
+
+    <source>
+        @id monitor_agent
+        @type monitor_agent
+    </source>
+
+    # input plugin that collects metrics from MonitorAgent
+    <source>
+        @id prometheus_monitor
+        @type prometheus_monitor
+        <labels>
+            host ${hostname}
+        </labels>
+    </source>
+
+    # input plugin that collects metrics for output plugin
+    <source>
+        @id prometheus_output_monitor
+        @type prometheus_output_monitor
+        <labels>
+            host ${hostname}
+        </labels>
+    </source>
+
+    # input plugin that collects metrics for in_tail plugin
+    <source>
+        @id prometheus_tail_monitor
+        @type prometheus_tail_monitor
+        <labels>
+            host ${hostname}
+        </labels>
+    </source>

--- a/e2e/resources/fluentd/fluentd-daemonset.yml
+++ b/e2e/resources/fluentd/fluentd-daemonset.yml
@@ -1,0 +1,115 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd-es
+  namespace: kube-system
+  labels:
+    k8s-app: fluentd-es
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fluentd-es
+  labels:
+    k8s-app: fluentd-es
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "namespaces"
+      - "pods"
+    verbs:
+      - "get"
+      - "watch"
+      - "list"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: fluentd-es
+  labels:
+    k8s-app: fluentd-es
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+subjects:
+  - kind: ServiceAccount
+    name: fluentd-es
+    namespace: kube-system
+    apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: fluentd-es
+  apiGroup: ""
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd-es
+  namespace: kube-system
+  labels:
+    k8s-app: fluentd-es
+    version: v0.0.2
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-es
+      version: v0.0.2
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-es
+        kubernetes.io/cluster-service: "true"
+        version: v0.0.2
+      # This annotation ensures that fluentd does not get evicted if the node
+      # supports critical pod annotation based priority scheme.
+      # Note that this does not guarantee admission on the nodes (#40573).
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: fluentd-es
+      containers:
+        - name: fluentd-es
+          image: skycirrus/fluentd-docker:latest
+          # As this is for e2e we don't want this image pulled from an external repo
+          imagePullPolicy: Never
+          env:
+            - name: FLUENTD_ARGS
+              value: "--no-supervisor -v"
+          resources:
+            limits:
+              memory: 500Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+            - name: es-template
+              mountPath: /etc/fluent/es-template
+            - name: varlog
+              mountPath: /var/log
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: config-volume
+              mountPath: /etc/fluent/config.d
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: config-volume
+          configMap:
+            name: fluentd-config
+        - name: es-template
+          configMap:
+            name: elasticsearch-template

--- a/e2e/resources/kibana/kibana-deployment.yml
+++ b/e2e/resources/kibana/kibana-deployment.yml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kibana-logging
+  namespace: kube-system
+  labels:
+    k8s-app: kibana-logging
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: kibana-logging
+  template:
+    metadata:
+      labels:
+        k8s-app: kibana-logging
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+    spec:
+      containers:
+        - name: kibana-logging
+          image: docker.elastic.co/kibana/kibana-oss:6.6.1
+          resources:
+            # need more cpu upon initialization, therefore burstable class
+            limits:
+              cpu: 1000m
+            requests:
+              cpu: 100m
+          env:
+            - name: ELASTICSEARCH_URL
+              value: http://elasticsearch-logging:9200
+          ports:
+            - containerPort: 5601
+              name: ui
+              protocol: TCP

--- a/e2e/resources/kibana/kibana-service.yml
+++ b/e2e/resources/kibana/kibana-service.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana-logging
+  namespace: kube-system
+  labels:
+    k8s-app: kibana-logging
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+    kubernetes.io/name: "Kibana"
+spec:
+  ports:
+    - port: 5601
+      protocol: TCP
+      targetPort: ui
+  selector:
+    k8s-app: kibana-logging

--- a/e2e/resources/logging-pod.yml
+++ b/e2e/resources/logging-pod.yml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: log-scenario-loki
+  labels:
+    team: loki
+spec:
+  terminationGracePeriodSeconds: 3
+  containers:
+    - image: alpine:3.2
+      env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: NORMAL_LOG
+          value: '{ "stringTest":  "key", "intTest": 10, "floatTest": 1.2, "objectTest": "broken" }'
+        - name: CLASHING_LOG
+          value: '{ "stringTest":  "key", "intTest": 10, "floatTest": 1.2, "objectTest": {"key":  "value"} }'
+        - name: TYPE_CLASH_LOG
+          value: '{ "stringTest":  "key", "intTest": "broken", "floatTest": 1.2, "objectTest": {"key":  "value"} }'
+      command: ["/bin/sh", "-ec","while true; do echo $NORMAL_LOG; echo $CLASHING_LOG; echo $TYPE_CLASH_LOG; sleep 30; end" ]
+      imagePullPolicy: IfNotPresent
+      name: alpine
+
+  restartPolicy: Never

--- a/fluent.conf
+++ b/fluent.conf
@@ -1,54 +1,8 @@
-<source>
-  @type forward
-  bind 0.0.0.0
-  port 24224
-</source>
+# This is the root config file, which only includes components of the actual configuration
 
-<match kubernetes.**>
-  @type rewrite_tag_filter
-  <rule>
-    key $['kubernetes']['labels']['app']
-    pattern ^(.+)$
-    tag $1.{{ .Values.global.cluster }}
-  </rule>
+# Do not collect fluentd's own logs to avoid infinite loops.
+<match fluent.**>
+  @type null
 </match>
 
-<match **>
-  @id elasticsearch
-  @type elasticsearch
-  @log_level info
-  include_tag_key true
-  host elasticsearch
-  port 9200
-  logstash_prefix ${tag}
-  <buffer>
-    @type file
-    path /fluentd/log/elasticsearch.all.buffer
-    flush_mode interval
-    flush_interval 5s
-    flush_thread_count 3
-    retry_max_interval 60
-    retry_forever
-    retry_type exponential_backoff
-    chunk_limit_size 2m
-    queue_limit_length 64
-    overflow_action block
-  </buffer>
-</match>
-
-<match fluent_bit>
-  @type stdout
-</match>
-
-<source>
-  @type prometheus
-  port 24231
-</source>
-
-<source>
-  @type prometheus_monitor
-</source>
-
-<source>
-  @type prometheus_output_monitor
-</source>
+@include /etc/fluent/config.d/*.conf

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These steps must be executed once the host /var and /lib volumes have
+# been mounted, and therefore cannot be done in the docker build stage.
+
+# For systems without journald
+mkdir -p /var/log/journal
+
+# Use exec to get the signal
+# A non-quoted string and add the comment to prevent shellcheck failures on this line.
+# See https://github.com/koalaman/shellcheck/wiki/SC2086
+# shellcheck disable=SC2086
+exec /usr/local/bin/fluentd $FLUENTD_ARGS


### PR DESCRIPTION
Adds resources to test a mapping configuration for kubernetes.
It attempts to solve the problem of a shared index between applications
that can cause mapping conflicts which lead to buffer saturation and
logging outages.

It uses Kubernetes in Docker (KinD) to startup the cluster and run the
locally built image with the custom configuration.
It deploys a pod that will log entries which would cause a conflict
mapping, and it would be expected that log-shipper will have no issues.

On a following PR the tests will be implemented to make sure that the
logs are being sent to the appropriate index.